### PR TITLE
Update serial_no.yaml

### DIFF
--- a/devices/serial_no.yaml
+++ b/devices/serial_no.yaml
@@ -4,7 +4,7 @@ text_sensor:
     id: serial_no
     lambda: |-
       std::string mac = get_mac_address();
-      return to_string("${serial_prefix}") + mac.erase(0, mac.length()/2);
+      return std::string("${serial_prefix}") + mac.substr(mac.length()/2);
     icon: mdi:expansion-card-variant
     entity_category: diagnostic
     update_interval: 60min


### PR DESCRIPTION
Fix for ESPHome 2025.7.0 compilation error (to_string on string)

Replaced to_string("${serial_prefix}") with std::string("${serial_prefix}") in serial_no.yaml to fix compilation with ESPHome 2025.7.0 and newer.