### PR TITLE
Replace deprecated IP address and sensor state APIs

### DIFF
--- a/packages/devices_v0_4/display.yaml
+++ b/packages/devices_v0_4/display.yaml
@@ -9,7 +9,7 @@ sensor:
         - text_sensor.template.publish:
             id: wt32_uptime
             state: !lambda |-
-              int seconds = round(id(wt32_uptime_seconds).raw_state);
+              int seconds = round(id(wt32_uptime_seconds).get_raw_state());
               int days = seconds / (24 * 3600);
               seconds = seconds % (24 * 3600);
               int hours = seconds / 3600;
@@ -33,7 +33,10 @@ text_sensor:
     entity_category: diagnostic
     icon: 'mdi:ip-network'
     lambda: |-
-      return id(eth).get_ip_addresses().empty() ? "Unset" : id(eth).get_ip_addresses()[0].str();
+      if (id(eth).get_ip_addresses().empty()) return {"Unset"};
+      char buf[esphome::network::IP_ADDRESS_BUFFER_SIZE];
+      id(eth).get_ip_addresses()[0].str_to(buf);
+      return {buf};
     update_interval: 60s
 
 script:

--- a/packages/devices_v0_5-v0_6/display.yaml
+++ b/packages/devices_v0_5-v0_6/display.yaml
@@ -9,7 +9,7 @@ sensor:
         - text_sensor.template.publish:
             id: wt32_uptime
             state: !lambda |-
-              int seconds = round(id(wt32_uptime_seconds).raw_state);
+              int seconds = round(id(wt32_uptime_seconds).get_raw_state());
               int days = seconds / (24 * 3600);
               seconds = seconds % (24 * 3600);
               int hours = seconds / 3600;
@@ -33,7 +33,10 @@ text_sensor:
     entity_category: diagnostic
     icon: 'mdi:ip-network'
     lambda: |-
-      return id(eth).get_ip_addresses().empty() ? "Unset" : id(eth).get_ip_addresses()[0].str();
+      if (id(eth).get_ip_addresses().empty()) return {"Unset"};
+      char buf[esphome::network::IP_ADDRESS_BUFFER_SIZE];
+      id(eth).get_ip_addresses()[0].str_to(buf);
+      return {buf};
     update_interval: 60s
 
 script:

--- a/packages/devices_v0_7/display.yaml
+++ b/packages/devices_v0_7/display.yaml
@@ -33,10 +33,10 @@ text_sensor:
     entity_category: diagnostic
     icon: 'mdi:ip-network'
     lambda: |-
-      if (id(eth).get_ip_addresses().empty()) return "Unset";
-      char buf[IP_ADDRESS_BUFFER_SIZE];
+      if (id(eth).get_ip_addresses().empty()) return {"Unset"};
+      char buf[esphome::network::IP_ADDRESS_BUFFER_SIZE];
       id(eth).get_ip_addresses()[0].str_to(buf);
-      return buf;
+      return {buf};
     update_interval: 60s
 
 script:

--- a/packages/devices_v0_7/display.yaml
+++ b/packages/devices_v0_7/display.yaml
@@ -9,7 +9,7 @@ sensor:
         - text_sensor.template.publish:
             id: wt32_uptime
             state: !lambda |-
-              int seconds = round(id(wt32_uptime_seconds).raw_state);
+              int seconds = round(id(wt32_uptime_seconds).get_raw_state());
               int days = seconds / (24 * 3600);
               seconds = seconds % (24 * 3600);
               int hours = seconds / 3600;
@@ -33,7 +33,10 @@ text_sensor:
     entity_category: diagnostic
     icon: 'mdi:ip-network'
     lambda: |-
-      return id(eth).get_ip_addresses().empty() ? "Unset" : id(eth).get_ip_addresses()[0].str();
+      if (id(eth).get_ip_addresses().empty()) return "Unset";
+      char buf[IP_ADDRESS_BUFFER_SIZE];
+      id(eth).get_ip_addresses()[0].str_to(buf);
+      return buf;
     update_interval: 60s
 
 script:

--- a/packages/devices_v0_9/display.yaml
+++ b/packages/devices_v0_9/display.yaml
@@ -9,7 +9,7 @@ sensor:
         - text_sensor.template.publish:
             id: wt32_uptime
             state: !lambda |-
-              int seconds = round(id(wt32_uptime_seconds).raw_state);
+              int seconds = round(id(wt32_uptime_seconds).get_raw_state());
               int days = seconds / (24 * 3600);
               seconds = seconds % (24 * 3600);
               int hours = seconds / 3600;
@@ -33,7 +33,10 @@ text_sensor:
     entity_category: diagnostic
     icon: 'mdi:ip-network'
     lambda: |-
-      return id(eth).get_ip_addresses().empty() ? "Unset" : id(eth).get_ip_addresses()[0].str();
+      if (id(eth).get_ip_addresses().empty()) return {"Unset"};
+      char buf[esphome::network::IP_ADDRESS_BUFFER_SIZE];
+      id(eth).get_ip_addresses()[0].str_to(buf);
+      return {buf};
     update_interval: 60s
 
 script:


### PR DESCRIPTION
Fix deprecation warnings that would cause build errors in future ESPHome versions.

Changes:
- Replace deprecated `.str()` with `str_to(buf)` using `esphome::network::IP_ADDRESS_BUFFER_SIZE` for IP address formatting (to be removed in ESPHome 2026.8.0)
- Replace deprecated `.raw_state` with `get_raw_state()` for sensor state access (to be removed in ESPHome 2026.10.0)